### PR TITLE
Add libnvidia-gpucomp to the list of NVIDIA driver libraries

### DIFF
--- a/src/nixglhost.py
+++ b/src/nixglhost.py
@@ -190,6 +190,7 @@ NVIDIA_DSO_PATTERNS = [
     "libnvidia-glcore\.so.*$",
     "libnvidia-glsi\.so.*$",
     "libnvidia-glvkspirv\.so.*$",
+    "libnvidia-gpucomp\.so.*$",
     "libnvidia-ml\.so.*$",
     "libnvidia-ngx\.so.*$",
     "libnvidia-nvvm\.so.*$",


### PR DESCRIPTION
Upcoming versions of the NVIDIA driver will include a new component:

https://forums.developer.nvidia.com/t/new-driver-component-libnvidia-gpucomp/267060

Update the list of NVIDIA driver libraries so that it can be included in the runtime environment along with the others.