### PR TITLE
chore: add flake checks

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -10,23 +10,19 @@
         "x86_64-linux"
         "aarch64-linux"
       ];
-      forAllSystems = f: nixpkgs.lib.genAttrs systems (system: f system);
-      pkgs = system: import nixpkgs {
-        inherit system;
-      };
+      eachSystem = f: nixpkgs.lib.genAttrs systems (system: f nixpkgs.legacyPackages.${system});
     in
     {
-      defaultPackage = forAllSystems (system: import ./default.nix { pkgs = pkgs system; });
+      packages = eachSystem (pkgs: {
+        default = import ./. { inherit pkgs; };
+      });
 
-      legacyPackages = forAllSystems (system: (pkgs system));
-
-      devShell = forAllSystems (system:
-        nixpkgs.legacyPackages.${system}.callPackage ./shell.nix { }
+      devShell = eachSystem (pkgs:
+        pkgs.callPackage ./shell.nix { }
       );
 
-      formatter = forAllSystems (system:
-        nixpkgs.legacyPackages.${system}.nixpkgs-fmt
-      );
+      formatter = eachSystem (pkgs: pkgs.nixpkgs-fmt);
 
+      checks = self.packages;
     };
 }


### PR DESCRIPTION
Cleanup the flake.nix a bit to make it more readable, and re-expose the package as a flake check, so that it works with buildbot-nix