### PR TITLE
Reintroduce defaultPackage

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -15,6 +15,7 @@
     {
       packages = eachSystem (pkgs: {
         default = import ./. { inherit pkgs; };
+        defaultPackage = import ./. { inherit pkgs; };
       });
 
       devShell = eachSystem (pkgs:


### PR DESCRIPTION
Yeah, it's deprecated https://github.com/NixOS/nix/issues/5532. But that's the API we were fulfilling, let's be stable.

Fixes https://github.com/numtide/nix-gl-host/issues/22