### PR TITLE
Update nixglhost.py to pass all remainder ARGS to NIX_BINARY

### DIFF
--- a/src/nixglhost.py
+++ b/src/nixglhost.py
@@ -665,8 +665,7 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "ARGS",
-        type=str,
-        nargs="*",
+        nargs=argparse.REMAINDER,
         help="The args passed to the wrapped binary.",
         default=None,
     )


### PR DESCRIPTION
addresses https://github.com/numtide/nix-gl-host/issues/26

- this is technically breaking behavior wrt current shell semantics (because you can run `nixglhost my-binary -- -arg1 -argn` right now; but this PR makes the `--` token also an arg)
- no other testing beyond verification in the shell that e.g. `nixglhost date -u` works as expected