### PR TITLE
Don't fail on inaccessible paths

### DIFF
--- a/src/nixglhost.py
+++ b/src/nixglhost.py
@@ -302,12 +302,15 @@ def resolve_libraries(path: str, files_patterns: List[str]) -> List[ResolvedLib]
                 return True
         return False
 
-    for fname in os.listdir(path):
-        abs_file_path = os.path.abspath(os.path.join(path, fname))
-        if os.path.isfile(abs_file_path) and is_dso_matching_pattern(abs_file_path):
-            libraries.append(
-                ResolvedLib(name=fname, dirpath=path, fullpath=abs_file_path)
-            )
+    try:
+        for fname in os.listdir(path):
+            abs_file_path = os.path.abspath(os.path.join(path, fname))
+            if os.path.isfile(abs_file_path) and is_dso_matching_pattern(abs_file_path):
+                libraries.append(
+                    ResolvedLib(name=fname, dirpath=path, fullpath=abs_file_path)
+                )
+    except PermissionError as err:
+        print(f"WARNING: {err}", file=sys.stderr)
     return libraries
 
 


### PR DESCRIPTION
When a library path (from `/etc/ld.so.conf` or `LD_LIBRARY_PATH`) is not accessible for the current user, `nixglhost` fails. For example:

    $ LD_LIBRARY_PATH=/root nixglhost ls
    ...
    File "/nix/store/ch7nppfsp3zpdyimralb1zc5h6dpz9sx-nix-gl-host-0.1/bin/nixglhost", line 302, in resolve_libraries
        for fname in os.listdir(path):
                     ^^^^^^^^^^^^^^^^
    PermissionError: [Errno 13] Permission denied: '/root'

This patch fixes that by printing a warning and continuing:

    $ LD_LIBRARY_PATH=/root nixglhost ls
    WARNING: [Errno 13] Permission denied: '/root'
    README.md ...