### PR TITLE
Properly escape in Python

### DIFF
--- a/src/nixglhost.py
+++ b/src/nixglhost.py
@@ -177,62 +177,62 @@ class CacheDirContent:
 # requiring to build/fetch the nvidia driver at runtime*.
 # TODO: compile the regexes
 NVIDIA_DSO_PATTERNS = [
-    "libGLESv1_CM_nvidia\.so.*$",
-    "libGLESv2_nvidia\.so.*$",
-    "libglxserver_nvidia\.so.*$",
-    "libnvcuvid\.so.*$",
-    "libnvidia-allocator\.so.*$",
-    "libnvidia-cfg\.so.*$",
-    "libnvidia-compiler\.so.*$",
-    "libnvidia-eglcore\.so.*$",
-    "libnvidia-encode\.so.*$",
-    "libnvidia-fbc\.so.*$",
-    "libnvidia-glcore\.so.*$",
-    "libnvidia-glsi\.so.*$",
-    "libnvidia-glvkspirv\.so.*$",
-    "libnvidia-gpucomp\.so.*$",
-    "libnvidia-ml\.so.*$",
-    "libnvidia-ngx\.so.*$",
-    "libnvidia-nvvm\.so.*$",
-    "libnvidia-opencl\.so.*$",
-    "libnvidia-opticalflow\.so.*$",
-    "libnvidia-ptxjitcompiler\.so.*$",
-    "libnvidia-rtcore\.so.*$",
-    "libnvidia-tls\.so.*$",
-    "libnvidia-vulkan-producer\.so.*$",
-    "libnvidia-wayland-client\.so.*$",
-    "libnvoptix\.so.*$",
+    "libGLESv1_CM_nvidia\\.so.*$",
+    "libGLESv2_nvidia\\.so.*$",
+    "libglxserver_nvidia\\.so.*$",
+    "libnvcuvid\\.so.*$",
+    "libnvidia-allocator\\.so.*$",
+    "libnvidia-cfg\\.so.*$",
+    "libnvidia-compiler\\.so.*$",
+    "libnvidia-eglcore\\.so.*$",
+    "libnvidia-encode\\.so.*$",
+    "libnvidia-fbc\\.so.*$",
+    "libnvidia-glcore\\.so.*$",
+    "libnvidia-glsi\\.so.*$",
+    "libnvidia-glvkspirv\\.so.*$",
+    "libnvidia-gpucomp\\.so.*$",
+    "libnvidia-ml\\.so.*$",
+    "libnvidia-ngx\\.so.*$",
+    "libnvidia-nvvm\\.so.*$",
+    "libnvidia-opencl\\.so.*$",
+    "libnvidia-opticalflow\\.so.*$",
+    "libnvidia-ptxjitcompiler\\.so.*$",
+    "libnvidia-rtcore\\.so.*$",
+    "libnvidia-tls\\.so.*$",
+    "libnvidia-vulkan-producer\\.so.*$",
+    "libnvidia-wayland-client\\.so.*$",
+    "libnvoptix\\.so.*$",
     # Cannot find that one :(
-    "libnvtegrahv\.so.*$",
+    "libnvtegrahv\\.so.*$",
     # Host dependencies required by the nvidia DSOs to properly
     # operate
     # libdrm
-    "libdrm\.so.*$",
+    "libdrm\\.so.*$",
     # libffi
-    "libffi\.so.*$",
+    "libffi\\.so.*$",
     # libgbm
-    "libgbm\.so.*$",
+    "libgbm\\.so.*$",
     # libexpat
-    "libexpat\.so.*$",
+    "libexpat\\.so.*$",
     # libxcb
-    "libxcb-glx\.so.*$",
+    "libxcb-glx\\.so.*$",
     # Coming from libx11
-    "libX11-xcb\.so.*$",
-    "libX11\.so.*$",
-    "libXext\.so.*$",
+    "libX11-xcb\\.so.*$",
+    "libX11\\.so.*$",
+    "libXext\\.so.*$",
     # libwayland
-    "libwayland-server\.so.*$",
-    "libwayland-client\.so.*$",
+    "libwayland-server\\.so.*$",
+    "libwayland-client\\.so.*$",
 ]
 
-CUDA_DSO_PATTERNS = ["libcudadebugger\.so.*$", "libcuda\.so.*$"]
+CUDA_DSO_PATTERNS = ["libcudadebugger\\.so.*$", "libcuda\\.so.*$"]
 
-GLX_DSO_PATTERNS = ["libGLX_nvidia\.so.*$"]
+GLX_DSO_PATTERNS = ["libGLX_nvidia\\.so.*$"]
 
 EGL_DSO_PATTERNS = [
-    "libEGL_nvidia\.so.*$",
-    "libnvidia-egl-wayland\.so.*$",
-    "libnvidia-egl-gbm\.so.*$",
+    "libEGL_nvidia\\.so.*$",
+    "libnvidia-egl-wayland\\.so.*$",
+    "libnvidia-egl-gbm\\.so.*$",
 ]
 
 


### PR DESCRIPTION
This PR avoids the warning:
> <stdin>:1: SyntaxWarning: invalid escape sequence '\.'