### PR TITLE
Move libnvidia-ml.so to CUDA_DSO_PATTERNS

### DIFF
--- a/src/nixglhost.py
+++ b/src/nixglhost.py
@@ -191,7 +191,6 @@ NVIDIA_DSO_PATTERNS = [
     "libnvidia-glsi\\.so.*$",
     "libnvidia-glvkspirv\\.so.*$",
     "libnvidia-gpucomp\\.so.*$",
-    "libnvidia-ml\\.so.*$",
     "libnvidia-ngx\\.so.*$",
     "libnvidia-nvvm\\.so.*$",
     "libnvidia-opencl\\.so.*$",
@@ -229,7 +228,11 @@ NVIDIA_DSO_PATTERNS = [
     "libdxcore\\.so.*$",
 ]
 
-CUDA_DSO_PATTERNS = ["libcudadebugger\\.so.*$", "libcuda\\.so.*$"]
+CUDA_DSO_PATTERNS = [
+    "libcudadebugger\\.so.*$",
+    "libcuda\\.so.*$",
+    "libnvidia-ml\\.so.*$",
+]
 
 GLX_DSO_PATTERNS = ["libGLX_nvidia\\.so.*$"]
 


### PR DESCRIPTION
As discussed in https://github.com/numtide/nix-gl-host/pull/19 libnvidia-ml.so is useful for nvidia-smi. Let's add it to `CUDA_DSO_PATTERNS`.