### PR TITLE
Respect chained symlink structure when copying files to the nix-gl-host cache

### DIFF
--- a/src/nixglhost.py
+++ b/src/nixglhost.py
@@ -12,11 +12,12 @@ import subprocess
 import sys
 import tempfile
 import time
+from pathlib import Path
 from glob import glob
 from typing import List, Literal, Dict, Tuple, TypedDict, TextIO, Optional
 
 IN_NIX_STORE = False
-CACHE_VERSION = 3
+CACHE_VERSION = 4
 
 
 if IN_NIX_STORE:
@@ -38,10 +39,14 @@ class ResolvedLib:
         fullpath: str,
         last_modification: Optional[float] = None,
         size: Optional[int] = None,
+        is_symlink: bool = False,
+        symlink_target: Optional[str] = None,
     ):
         self.name: str = name
         self.dirpath: str = dirpath
         self.fullpath: str = fullpath
+        self.is_symlink: bool = is_symlink
+        self.symlink_target: Optional[str] = symlink_target
         if size is None or last_modification is None:
             stat = os.stat(fullpath)
             self.last_modification: float = stat.st_mtime
@@ -51,7 +56,7 @@ class ResolvedLib:
             self.size = size
 
     def __repr__(self):
-        return f"ResolvedLib<{self.name}, {self.dirpath}, {self.fullpath}, {self.last_modification}, {self.size}>"
+        return f"ResolvedLib<{self.name}, {self.dirpath}, {self.fullpath}, {self.last_modification}, {self.size}, is_symlink={self.is_symlink}, target={self.symlink_target}>"
 
     def to_dict(self) -> Dict:
         return {
@@ -60,11 +65,21 @@ class ResolvedLib:
             "fullpath": self.fullpath,
             "last_modification": self.last_modification,
             "size": self.size,
+            "is_symlink": self.is_symlink,
+            "symlink_target": self.symlink_target,
         }
 
     def __hash__(self):
         return hash(
-            (self.name, self.dirpath, self.fullpath, self.last_modification, self.size)
+            (
+                self.name,
+                self.dirpath,
+                self.fullpath,
+                self.last_modification,
+                self.size,
+                self.is_symlink,
+                self.symlink_target,
+            )
         )
 
     def __eq__(self, o):
@@ -74,12 +89,20 @@ class ResolvedLib:
             and self.dirpath == o.dirpath
             and self.last_modification == o.last_modification
             and self.size == o.size
+            and self.is_symlink == o.is_symlink
+            and self.symlink_target == o.symlink_target
         )
 
     @classmethod
     def from_dict(cls, d: Dict):
         return ResolvedLib(
-            d["name"], d["dirpath"], d["fullpath"], d["last_modification"], d["size"]
+            d["name"],
+            d["dirpath"],
+            d["fullpath"],
+            d["last_modification"],
+            d["size"],
+            d.get("is_symlink", False),
+            d.get("symlink_target", None),
         )
 
 
@@ -319,11 +342,25 @@ def resolve_libraries(path: str, files_patterns: List[str]) -> List[ResolvedLib]
         return False
 
     try:
-        for fname in os.listdir(path):
-            abs_file_path = os.path.abspath(os.path.join(path, fname))
-            if os.path.isfile(abs_file_path) and is_dso_matching_pattern(abs_file_path):
+        path_obj = Path(path)
+        for item in path_obj.iterdir():
+            # Check if it's a file or symlink and matches pattern
+            if (item.is_file() or item.is_symlink()) and is_dso_matching_pattern(
+                str(item)
+            ):
+                is_symlink = item.is_symlink()
+                symlink_target = None
+                if is_symlink:
+                    # Get the symlink target (relative path as stored in the symlink)
+                    symlink_target = str(item.readlink())
                 libraries.append(
-                    ResolvedLib(name=fname, dirpath=path, fullpath=abs_file_path)
+                    ResolvedLib(
+                        name=item.name,
+                        dirpath=str(path_obj),
+                        fullpath=str(item.absolute()),
+                        is_symlink=is_symlink,
+                        symlink_target=symlink_target,
+                    )
                 )
     except PermissionError as err:
         print(f"WARNING: {err}", file=sys.stderr)
@@ -343,18 +380,52 @@ def copy_and_patch_libs(
 
     We also don't want to directly modify the host DSOs. In the end,
     we first copy them to the user's personal cache directory, we then
-    alter their runpath to point to the cache directory."""
+    alter their runpath to point to the cache directory.
+
+    This function preserves symlink structure by first copying real files,
+    then creating symlinks."""
     rpath = rpath if (rpath is not None) else dest_dir
+    dest_path = Path(dest_dir)
     new_paths: List[str] = []
-    for dso in dsos:
-        basename = os.path.basename(dso.fullpath)
-        newpath = os.path.join(dest_dir, basename)
-        log_info(f"Copying and patching {dso} to {newpath}")
+
+    # Separate real files and symlinks
+    real_files = [dso for dso in dsos if not dso.is_symlink]
+    symlinks = [dso for dso in dsos if dso.is_symlink]
+
+    # First, copy all real files
+    for dso in real_files:
+        source_path = Path(dso.fullpath)
+        newpath = dest_path / source_path.name
+        log_info(f"Copying {dso.fullpath} to {newpath}")
         shutil.copyfile(dso.fullpath, newpath)
         # Provide write permissions to ensure we can patch this binary.
-        os.chmod(newpath, os.stat(dso.fullpath).st_mode | stat.S_IWUSR)
-        new_paths.append(newpath)
-    patch_dsos(new_paths, rpath)
+        newpath.chmod(newpath.stat().st_mode | stat.S_IWUSR)
+        new_paths.append(str(newpath))
+
+    # Then, recreate all symlinks with their relative targets
+    # No need to sort - symlinks can be created even if their target doesn't exist yet
+    for dso in symlinks:
+        source_path = Path(dso.fullpath)
+        newpath = dest_path / source_path.name
+
+        # Validate that symlink target is in the same directory
+        if dso.symlink_target and (
+            "/" in dso.symlink_target or dso.symlink_target.startswith("..")
+        ):
+            print(
+                f"WARNING: Symlink {dso.name} points outside its directory: {dso.symlink_target}. "
+                f"This may result in a broken symlink in the cache.",
+                file=sys.stderr,
+            )
+
+        log_info(f"Creating symlink {newpath} -> {dso.symlink_target}")
+        if newpath.exists() or newpath.is_symlink():
+            newpath.unlink()
+        newpath.symlink_to(dso.symlink_target)
+
+    # Only patch real files, not symlinks
+    if new_paths:
+        patch_dsos(new_paths, rpath)
 
 
 def log_info(string: str) -> None:

--- a/src/nixglhost_test.py
+++ b/src/nixglhost_test.py
@@ -1,7 +1,17 @@
 import unittest
 import os
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
 
-from nixglhost import CacheDirContent, LibraryPath, ResolvedLib
+from nixglhost import (
+    CacheDirContent,
+    LibraryPath,
+    ResolvedLib,
+    resolve_libraries,
+    copy_and_patch_libs,
+    CUDA_DSO_PATTERNS,
+)
 
 
 class TestCacheSerializer(unittest.TestCase):
@@ -70,6 +80,222 @@ class TestCacheSerializer(unittest.TestCase):
         self.assertEqual(cdc, commut_cdc)
         self.assertNotEqual(cdc, wrong_cdc)
         self.assertNotEqual(commut_cdc, wrong_cdc)
+
+
+class TestSymlinkPreservation(unittest.TestCase):
+    """Tests for symlink structure preservation"""
+
+    def setUp(self):
+        """Create a temporary directory with test files and symlinks"""
+        self.temp_dir = tempfile.mkdtemp()
+        self.source_dir = Path(self.temp_dir) / "source"
+        self.dest_dir = Path(self.temp_dir) / "dest"
+        self.source_dir.mkdir()
+        self.dest_dir.mkdir()
+
+    def tearDown(self):
+        """Clean up temporary directory"""
+        import shutil
+
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def test_resolve_libraries_detects_symlinks(self):
+        """Test that resolve_libraries correctly identifies symlinks"""
+        # Create a real file
+        real_file = self.source_dir / "libcuda.so.565.57.01"
+        real_file.write_text("fake library content")
+
+        # Create symlink chain
+        (self.source_dir / "libcuda.so.1").symlink_to("libcuda.so.565.57.01")
+        (self.source_dir / "libcuda.so").symlink_to("libcuda.so.1")
+
+        # Resolve libraries
+        resolved_libs = resolve_libraries(str(self.source_dir), CUDA_DSO_PATTERNS)
+
+        # Should find 3 items (1 real file + 2 symlinks)
+        self.assertEqual(len(resolved_libs), 3)
+
+        # Find each library type
+        libs_by_name = {lib.name: lib for lib in resolved_libs}
+
+        # Check the real file
+        self.assertIn("libcuda.so.565.57.01", libs_by_name)
+        self.assertFalse(libs_by_name["libcuda.so.565.57.01"].is_symlink)
+        self.assertIsNone(libs_by_name["libcuda.so.565.57.01"].symlink_target)
+
+        # Check first symlink
+        self.assertIn("libcuda.so.1", libs_by_name)
+        self.assertTrue(libs_by_name["libcuda.so.1"].is_symlink)
+        self.assertEqual(
+            libs_by_name["libcuda.so.1"].symlink_target, "libcuda.so.565.57.01"
+        )
+
+        # Check second symlink
+        self.assertIn("libcuda.so", libs_by_name)
+        self.assertTrue(libs_by_name["libcuda.so"].is_symlink)
+        self.assertEqual(libs_by_name["libcuda.so"].symlink_target, "libcuda.so.1")
+
+    def test_symlink_structure_preserved_after_copy(self):
+        """Test that copy_and_patch_libs preserves symlink structure"""
+        # Create test files
+        real_file = self.source_dir / "libcuda.so.565.57.01"
+        real_file.write_text("fake library content")
+        (self.source_dir / "libcuda.so.1").symlink_to("libcuda.so.565.57.01")
+        (self.source_dir / "libcuda.so").symlink_to("libcuda.so.1")
+
+        # Resolve libraries
+        resolved_libs = resolve_libraries(str(self.source_dir), CUDA_DSO_PATTERNS)
+
+        # Mock patch_dsos to avoid calling patchelf
+        with patch("nixglhost.patch_dsos"):
+            copy_and_patch_libs(resolved_libs, str(self.dest_dir))
+
+        # Verify all files/symlinks were copied
+        self.assertTrue((self.dest_dir / "libcuda.so.565.57.01").exists())
+        self.assertTrue((self.dest_dir / "libcuda.so.1").exists())
+        self.assertTrue((self.dest_dir / "libcuda.so").exists())
+
+        # Verify symlink structure
+        self.assertFalse((self.dest_dir / "libcuda.so.565.57.01").is_symlink())
+        self.assertTrue((self.dest_dir / "libcuda.so.1").is_symlink())
+        self.assertTrue((self.dest_dir / "libcuda.so").is_symlink())
+
+        # Verify symlink targets
+        self.assertEqual(
+            str((self.dest_dir / "libcuda.so.1").readlink()), "libcuda.so.565.57.01"
+        )
+        self.assertEqual(str((self.dest_dir / "libcuda.so").readlink()), "libcuda.so.1")
+
+    def test_symlink_chain_resolution(self):
+        """Test that complex symlink chains are correctly preserved"""
+        # Create a real file
+        real_file = self.source_dir / "libnvidia-ml.so.565.57.01"
+        real_file.write_text("fake nvidia-ml library")
+
+        # Create multiple levels of symlinks
+        (self.source_dir / "libnvidia-ml.so.1").symlink_to("libnvidia-ml.so.565.57.01")
+        (self.source_dir / "libnvidia-ml.so").symlink_to("libnvidia-ml.so.1")
+
+        resolved_libs = resolve_libraries(str(self.source_dir), CUDA_DSO_PATTERNS)
+
+        with patch("nixglhost.patch_dsos"):
+            copy_and_patch_libs(resolved_libs, str(self.dest_dir))
+
+        # Verify the entire chain resolves correctly
+        final_target = (self.dest_dir / "libnvidia-ml.so").resolve()
+        self.assertEqual(final_target.name, "libnvidia-ml.so.565.57.01")
+
+        # Verify each link in the chain
+        first_link_target = (self.dest_dir / "libnvidia-ml.so").readlink()
+        self.assertEqual(str(first_link_target), "libnvidia-ml.so.1")
+
+        second_link_target = (self.dest_dir / "libnvidia-ml.so.1").readlink()
+        self.assertEqual(str(second_link_target), "libnvidia-ml.so.565.57.01")
+
+    def test_resolved_lib_serialization_with_symlinks(self):
+        """Test that ResolvedLib with symlink info serializes correctly"""
+        lib_symlink = ResolvedLib(
+            name="libcuda.so",
+            dirpath="/usr/lib",
+            fullpath="/usr/lib/libcuda.so",
+            last_modification=1234567890.0,
+            size=0,
+            is_symlink=True,
+            symlink_target="libcuda.so.1",
+        )
+
+        # Convert to dict and back
+        lib_dict = lib_symlink.to_dict()
+        lib_restored = ResolvedLib.from_dict(lib_dict)
+
+        # Verify symlink info is preserved
+        self.assertTrue(lib_restored.is_symlink)
+        self.assertEqual(lib_restored.symlink_target, "libcuda.so.1")
+        self.assertEqual(lib_symlink, lib_restored)
+
+    def test_cache_version_with_symlinks(self):
+        """Test that cache with symlinks serializes correctly"""
+        lib_real = ResolvedLib(
+            name="libcuda.so.565.57.01",
+            dirpath="/usr/lib",
+            fullpath="/usr/lib/libcuda.so.565.57.01",
+            last_modification=1234567890.0,
+            size=1024,
+            is_symlink=False,
+            symlink_target=None,
+        )
+
+        lib_symlink = ResolvedLib(
+            name="libcuda.so",
+            dirpath="/usr/lib",
+            fullpath="/usr/lib/libcuda.so",
+            last_modification=1234567890.0,
+            size=0,
+            is_symlink=True,
+            symlink_target="libcuda.so.565.57.01",
+        )
+
+        lp = LibraryPath(
+            glx=[], cuda=[lib_real, lib_symlink], generic=[], egl=[], path="/usr/lib"
+        )
+
+        cache = CacheDirContent([lp])
+        json_str = cache.to_json()
+
+        # Deserialize and verify
+        cache_restored = CacheDirContent.from_json(json_str)
+        self.assertEqual(cache, cache_restored)
+
+        # Verify symlink info is in the restored cache
+        restored_cuda_libs = cache_restored.paths[0].cuda
+        symlink_libs = [lib for lib in restored_cuda_libs if lib.is_symlink]
+        self.assertEqual(len(symlink_libs), 1)
+        self.assertEqual(symlink_libs[0].symlink_target, "libcuda.so.565.57.01")
+
+    def test_symlink_pointing_outside_directory_warns(self):
+        """Test that symlinks pointing outside the directory generate warnings"""
+        import sys
+        from io import StringIO
+
+        # Create a real file
+        real_file = self.source_dir / "libcuda.so.565.57.01"
+        real_file.write_text("fake library content")
+
+        # Manually create a ResolvedLib with a symlink pointing outside
+        lib_with_bad_symlink = ResolvedLib(
+            name="libcuda.so",
+            dirpath=str(self.source_dir),
+            fullpath=str(self.source_dir / "libcuda.so"),
+            last_modification=1234567890.0,
+            size=0,
+            is_symlink=True,
+            symlink_target="../other/libcuda.so.565.57.01",
+        )
+
+        lib_real = ResolvedLib(
+            name="libcuda.so.565.57.01",
+            dirpath=str(self.source_dir),
+            fullpath=str(real_file),
+            is_symlink=False,
+            symlink_target=None,
+        )
+
+        # Capture stderr to check for warning
+        old_stderr = sys.stderr
+        sys.stderr = StringIO()
+
+        try:
+            with patch("nixglhost.patch_dsos"):
+                copy_and_patch_libs(
+                    [lib_real, lib_with_bad_symlink], str(self.dest_dir)
+                )
+
+            stderr_output = sys.stderr.getvalue()
+            self.assertIn("WARNING", stderr_output)
+            self.assertIn("points outside its directory", stderr_output)
+            self.assertIn("../other/libcuda.so.565.57.01", stderr_output)
+        finally:
+            sys.stderr = old_stderr
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Issue

When copying libraries to the `nix-gl-host` cache, the current code uses `shutil.copyfile()` which follows symlinks and copies the actual file content.
This breaks in some situations where code expects the typical chains of symlinks (e.g. `libcuda.so` -> `libcuda.so.1` -> `libcuda.so.565.57.01`).

This is the case, for example, when you import PyTorch and Warp (from Nvidia), PyTorch loads `libcuda.so.1` while Warp loads `libcuda.so`

# Patch

The changes in this PR basically make sure to only copy the *actual* library and then simply reproduce the symlinks chains, which are usually relative to the current directory:

```
> ls -la /usr/lib/x86_64-linux-gnu/ | grep libcuda.so
lrwxrwxrwx   1 root  root         12 Oct 15  2024 libcuda.so -> libcuda.so.1
lrwxrwxrwx   1 root  root         20 Oct 15  2024 libcuda.so.1 -> libcuda.so.565.57.01
-rw-r--r--   1 root  root   49554296 Oct 10  2024 libcuda.so.565.57.01
```

The `nix-gl-host` cache now looks like this:

```
> cd ~/.cache/nix-gl-host/.../cuda  && ls -la | grep libcuda.so
lrwxrwxrwx 1 me me       12 Oct  3 13:00 libcuda.so -> libcuda.so.1
lrwxrwxrwx 1 me me       20 Oct  3 13:00 libcuda.so.1 -> libcuda.so.565.57.01
-rw-rw-r-- 1 me me 49576080 Oct  3 13:00 libcuda.so.565.57.01
```